### PR TITLE
Update deprecated function and event to remove console warnings

### DIFF
--- a/frontend/src/components/Dapp.js
+++ b/frontend/src/components/Dapp.js
@@ -173,7 +173,7 @@ export class Dapp extends React.Component {
 
     // To connect to the user's wallet, we have to run this method.
     // It returns a promise that will resolve to the user's address.
-    const [selectedAddress] = await window.ethereum.enable();
+    const [selectedAddress] = await window.ethereum.request({ method: 'eth_requestAccounts' });
 
     // Once we have the address, we can initialize the application.
 
@@ -199,7 +199,7 @@ export class Dapp extends React.Component {
     });
     
     // We reset the dapp state if the network is changed
-    window.ethereum.on("networkChanged", ([networkId]) => {
+    window.ethereum.on("chainChanged", ([networkId]) => {
       this._stopPollingData();
       this._resetState();
     });


### PR DESCRIPTION
It seems that the following code has been deprecated and replaced. This PR handles these updates:

`'ethereum.enable()' is deprecated and may be removed in the future. Please use the 'eth_requestAccounts' RPC method instead.`

`The event 'networkChanged' is deprecated and may be removed in the future. Use 'chainChanged' instead.`