### PR TITLE
Add comments for MetaMask users to quickly fix chainId bug

### DIFF
--- a/frontend/src/components/Dapp.js
+++ b/frontend/src/components/Dapp.js
@@ -23,7 +23,7 @@ import { NoTokensMessage } from "./NoTokensMessage";
 // If you are using MetaMask, be sure to change the Network id to 1337.
 // Here's a list of network ids https://docs.metamask.io/guide/ethereum-provider.html#properties
 // to use when deploying to other networks.
-const HARDHAT_NETWORK_ID = '1337';
+const HARDHAT_NETWORK_ID = '31337';
 
 // This is an error code that indicates that the user canceled a transaction
 const ERROR_CODE_TX_REJECTED_BY_USER = 4001;
@@ -343,7 +343,11 @@ export class Dapp extends React.Component {
   // This is an utility method that turns an RPC error into a human readable
   // message.
   _getRpcErrorMessage(error) {
-    return error.data ? error.data.message : error.message;
+    if (error.data) {
+      return error.data.message;
+    }
+
+    return error.message;
   }
 
   // This method resets the state

--- a/frontend/src/components/Dapp.js
+++ b/frontend/src/components/Dapp.js
@@ -19,10 +19,11 @@ import { TransactionErrorMessage } from "./TransactionErrorMessage";
 import { WaitingForTransactionMessage } from "./WaitingForTransactionMessage";
 import { NoTokensMessage } from "./NoTokensMessage";
 
-// This is the Hardhat Network id, you might change it in the hardhat.config.js
+// This is the Hardhat Network id, you might change it in the hardhat.config.js.
+// If you are using MetaMask, be sure to change the Network id to 1337.
 // Here's a list of network ids https://docs.metamask.io/guide/ethereum-provider.html#properties
 // to use when deploying to other networks.
-const HARDHAT_NETWORK_ID = '31337';
+const HARDHAT_NETWORK_ID = '1337';
 
 // This is an error code that indicates that the user canceled a transaction
 const ERROR_CODE_TX_REJECTED_BY_USER = 4001;
@@ -342,11 +343,7 @@ export class Dapp extends React.Component {
   // This is an utility method that turns an RPC error into a human readable
   // message.
   _getRpcErrorMessage(error) {
-    if (error.data) {
-      return error.data.message;
-    }
-
-    return error.message;
+    return error.data ? error.data.message : error.message;
   }
 
   // This method resets the state

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,6 +5,12 @@ require("@nomiclabs/hardhat-waffle");
 // testing the frontend.
 require("./tasks/faucet");
 
+// If you are using MetaMask, be sure to change the chainId to 1337
 module.exports = {
-  solidity: "0.7.3"
+  solidity: "0.7.3",
+  networks: {
+    hardhat: {
+      chainId: 31337
+    }
+  }
 };


### PR DESCRIPTION
According to the HardHat documentation ([https://hardhat.org/metamask-issue.htm]), there is a known MetaMask issue with the current `chainId` of 31337. Adding some comments to quickly fix this issue would save new users a lot of time.

In order to maintain the current implementation, I added the specified Network ID to the `hardhat.config.js` file and included some comments for MetaMask users to simply change the `chainId` to 1337.