### PR TITLE
Remove redundant code

### DIFF
--- a/test/Token.js
+++ b/test/Token.js
@@ -42,9 +42,6 @@ describe("Token contract", function () {
     // mined.
     hardhatToken = await Token.deploy();
     await hardhatToken.deployed();
-
-    // We can interact with the contract by calling `hardhatToken.method()`
-    await hardhatToken.deployed();
   });
 
   // You can nest describe calls to create subsections.
@@ -57,6 +54,7 @@ describe("Token contract", function () {
       // Expect receives a value, and wraps it in an assertion objet. These
       // objects have a lot of utility methods to assert values.
 
+      // We can interact with the contract by calling `hardhatToken.method()`
       // This test expects the owner variable stored in the contract to be equal
       // to our Signer's owner.
       expect(await hardhatToken.owner()).to.equal(owner.address);


### PR DESCRIPTION
This PR improves refactors the test file to remove the redundant line of code.
Also moved the comment to, what I felt would be, a better place. 
Worth adding another comment to clarify that the compiler automatically creates getter functions for all public state variables?

Looking forward to a review.