### PR TITLE
Remove duplicate hardhatToken.deployed() call in test set up

### DIFF
--- a/test/Token.js
+++ b/test/Token.js
@@ -41,7 +41,6 @@ describe("Token contract", function () {
     // for it to be deployed(), which happens onces its transaction has been
     // mined.
     hardhatToken = await Token.deploy();
-    await hardhatToken.deployed();
 
     // We can interact with the contract by calling `hardhatToken.method()`
     await hardhatToken.deployed();


### PR DESCRIPTION
Remove double `hardhatToken.deployed()` call mistake in test set up, as referenced in https://github.com/nomiclabs/hardhat-hackathon-boilerplate/issues/34 issue. Thanks!