### PR TITLE
MetaMask and localhost hardhat server on network id 1337

### DIFF
--- a/frontend/src/components/Dapp.js
+++ b/frontend/src/components/Dapp.js
@@ -20,7 +20,7 @@ import { WaitingForTransactionMessage } from "./WaitingForTransactionMessage";
 import { NoTokensMessage } from "./NoTokensMessage";
 
 // This is the default id used by the Hardhat Network
-const HARDHAT_NETWORK_ID = '31337';
+const HARDHAT_NETWORK_ID = '1337';
 
 // This is an error code that indicates that the user canceled a transaction
 const ERROR_CODE_TX_REJECTED_BY_USER = 4001;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,5 +7,10 @@ require("./tasks/faucet");
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
+  networks: {
+    hardhat: {
+      chainId: 1337
+    },
+  },
   solidity: "0.8.17",
 };


### PR DESCRIPTION
fix(metamask-localhost): Make MM work with network id 1337 on the local hardhat server.

This change was made due to information found here:
https://hardhat.org/hardhat-network/docs/metamask-issue