### PR TITLE
fixes so that the app can run

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,9 +6,7 @@
     "bootstrap": "^4.4.1",
     "ethers": "^5.4.7",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "devDependencies": {
+    "react-dom": "^18.2.0",
     "react-scripts": "5.0.1"
   },
   "scripts": {

--- a/frontend/src/components/Dapp.js
+++ b/frontend/src/components/Dapp.js
@@ -20,7 +20,7 @@ import { WaitingForTransactionMessage } from "./WaitingForTransactionMessage";
 import { NoTokensMessage } from "./NoTokensMessage";
 
 // This is the default id used by the Hardhat Network
-const HARDHAT_NETWORK_ID = '31337';
+const HARDHAT_NETWORK_ID = 31337;
 
 // This is an error code that indicates that the user canceled a transaction
 const ERROR_CODE_TX_REJECTED_BY_USER = 4001;
@@ -222,8 +222,7 @@ export class Dapp extends React.Component {
     this._token = new ethers.Contract(
       contractAddress.Token,
       TokenArtifact.abi,
-      this._provider.getSigner(0)
-    );
+      this._provider.getSigner(this.state.selectedAddress)    );
   }
 
   // The next two methods are needed to start and stop polling data. While
@@ -254,10 +253,11 @@ export class Dapp extends React.Component {
     this.setState({ tokenData: { name, symbol } });
   }
 
-  async _updateBalance() {
-    const balance = await this._token.balanceOf(this.state.selectedAddress);
-    this.setState({ balance });
-  }
+ async _updateBalance() {
+  if (!this.state.selectedAddress) return; // <-- early exit when there is no address selected
+  const balance = await this._token.balanceOf(this.state.selectedAddress);
+  this.setState({ balance });
+}
 
   // This method sends an ethereum transaction to transfer tokens.
   // While this action is specific to this application, it illustrates how to


### PR DESCRIPTION
When running the tutorial, I ran into the following issues:

- Building and running with `pnpm` exposed an issue, where `react-scripts` is in the `dev-dependencies`, whereas it had to be in the `dependencies` (as it is a runtime dependency)
    const chainIdHex = `0x${HARDHAT_NETWORK_ID.toString(16)}`

- Various runtime errors in the app: 
    - networkID is a string, which we treat as a number at a later point ( const chainIdHex = `0x${HARDHAT_NETWORK_ID.toString(16)}`) this causes the chainIdHex to be faulty, making the contract not discoverable.
    - before logging in to my web3provider, there is no `this.state.selectedaddress` defined. 
    - getSigner(0) can give the wrong key. getSigner(selectedAddress) is better.



